### PR TITLE
Remove data attributes if content animation is disabled

### DIFF
--- a/Configuration/TypoScript/BootstrapPackage/v13/setup.typoscript
+++ b/Configuration/TypoScript/BootstrapPackage/v13/setup.typoscript
@@ -14,25 +14,26 @@ lib.contentElement {
             data-aos = TEXT
             data-aos {
                 field = tx_content_animations_animation
+                fieldRequired = tx_content_animations_animation
             }
-            data-aos-duration = TEXT
+            data-aos-duration < .data-aos
             data-aos-duration {
                 field = tx_content_animations_duration
             }
-            data-aos-offset = TEXT
+            data-aos-offset < .data-aos
             data-aos-offset {
                 field = tx_content_animations_offset
             }
-            data-aos-delay = TEXT
+            data-aos-delay < .data-aos
             data-aos-delay {
                 field = tx_content_animations_delay
             }
-            data-aos-easing = TEXT
+            data-aos-easing < .data-aos
             data-aos-easing {
                 field = tx_content_animations_easing
                 ifEmpty = {$plugin.tx_content_animations.aos-easing}
             }
-            data-aos-mirror = TEXT
+            data-aos-mirror < .data-aos
             data-aos-mirror {
                 field = tx_content_animations_mirror
                 replacement.10 {
@@ -41,7 +42,7 @@ lib.contentElement {
                 }
                 ifEmpty = false
             }
-            data-aos-once = TEXT
+            data-aos-once < .data-aos
             data-aos-once {
                 field = tx_content_animations_once
                 replacement.10 {
@@ -50,7 +51,7 @@ lib.contentElement {
                 }
                 ifEmpty = false
             }
-            data-aos-anchor-placement = TEXT
+            data-aos-anchor-placement < .data-aos
             data-aos-anchor-placement {
                 field = tx_content_animations_anchor_placement
             }

--- a/Configuration/TypoScript/BootstrapPackage/v14/setup.typoscript
+++ b/Configuration/TypoScript/BootstrapPackage/v14/setup.typoscript
@@ -14,25 +14,26 @@ lib.contentElement {
             data-aos = TEXT
             data-aos {
                 field = tx_content_animations_animation
+                fieldRequired = tx_content_animations_animation
             }
-            data-aos-duration = TEXT
+            data-aos-duration < .data-aos
             data-aos-duration {
                 field = tx_content_animations_duration
             }
-            data-aos-offset = TEXT
+            data-aos-offset < .data-aos
             data-aos-offset {
                 field = tx_content_animations_offset
             }
-            data-aos-delay = TEXT
+            data-aos-delay < .data-aos
             data-aos-delay {
                 field = tx_content_animations_delay
             }
-            data-aos-easing = TEXT
+            data-aos-easing < .data-aos
             data-aos-easing {
                 field = tx_content_animations_easing
                 ifEmpty = {$plugin.tx_content_animations.aos-easing}
             }
-            data-aos-mirror = TEXT
+            data-aos-mirror < .data-aos
             data-aos-mirror {
                 field = tx_content_animations_mirror
                 replacement.10 {
@@ -41,7 +42,7 @@ lib.contentElement {
                 }
                 ifEmpty = false
             }
-            data-aos-once = TEXT
+            data-aos-once < .data-aos
             data-aos-once {
                 field = tx_content_animations_once
                 replacement.10 {
@@ -50,7 +51,7 @@ lib.contentElement {
                 }
                 ifEmpty = false
             }
-            data-aos-anchor-placement = TEXT
+            data-aos-anchor-placement < .data-aos
             data-aos-anchor-placement {
                 field = tx_content_animations_anchor_placement
             }


### PR DESCRIPTION
If no animation has been selected, the additional data attributes should not be inserted either. This change means that the data attributes are only inserted and used if the `tx_content_animations_animation` field actually contains a value.